### PR TITLE
Fix: enforce unique email validation

### DIFF
--- a/api/data/customerData.js
+++ b/api/data/customerData.js
@@ -79,13 +79,19 @@ const addCustomers = (request, response) => {
 		return response.status(400).json({ error: validationError });
 	}
 
+	const emailExists = customers.some(c => c.email === request.body.email);
+	if (emailExists) {
+		return response.status(409).json({ error: 'A customer with this email already exists' });
+	}
+
 	const newCustomer = { id: nextId++, ...pickCustomerFields(request.body) };
 	customers.push(newCustomer);
 	response.status(201).json(newCustomer);
 };
 
 const updateCustomer = (request, response) => {
-	const foundCustomer = customers.find((customer) => customer.id === Number(request.params.customerId));
+	const customerId = Number(request.params.customerId);
+	const foundCustomer = customers.find((customer) => customer.id === customerId);
 	if (!foundCustomer) {
 		return response.status(404).json({ error: CUSTOMER_NOT_FOUND });
 	}
@@ -93,6 +99,11 @@ const updateCustomer = (request, response) => {
 	const validationError = validateCustomer(request.body);
 	if (validationError) {
 		return response.status(400).json({ error: validationError });
+	}
+
+	const emailTaken = customers.some(c => c.email === request.body.email && c.id !== customerId);
+	if (emailTaken) {
+		return response.status(409).json({ error: 'A customer with this email already exists' });
 	}
 
 	Object.assign(foundCustomer, pickCustomerFields(request.body));


### PR DESCRIPTION
## Summary
- Reject customer creation (POST) with `409 Conflict` when email already exists
- Reject customer update (PUT) with `409 Conflict` when changing email to one already used by another customer
- Allows updating a customer without changing their email (no false positive on self-match)

## Test plan
- [x] Creating a customer with a new email returns 201
- [x] Creating a customer with a duplicate email returns 409
- [x] Updating a customer's email to a taken one returns 409
- [x] Updating a customer without changing email returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)